### PR TITLE
Add the ability to switch between watch faces

### DIFF
--- a/src/hardware/input/buttons.cpp
+++ b/src/hardware/input/buttons.cpp
@@ -41,32 +41,6 @@ buttonState useButton()
     return buttonPressedTmp;
 }
 
-// Should be used only in watchface
-buttonState peekButton()
-{
-    buttMut.lock();
-    buttonState btn = buttonPressed;
-    buttMut.unlock();
-    return btn;
-}
-
-// Like useButton() but leaves LongUp/LongDown unconsumed so the cycling
-// check in watchfaceManageAll can catch them on the next loop iteration.
-buttonState useButtonNoLong()
-{
-    buttMut.lock();
-    if (buttonPressed == LongDown || buttonPressed == LongUp ||
-        buttonPressed == Back     || buttonPressed == LongBack)
-    {
-        buttMut.unlock();
-        return None;
-    }
-    buttonState tmp = buttonPressed;
-    buttonPressed = None;
-    buttMut.unlock();
-    return tmp;
-}
-
 buttonState useAllButtons()
 {
     buttMut.lock();
@@ -74,7 +48,7 @@ buttonState useAllButtons()
     // {
     //     buttMut.unlock();
     //     return None;
-    // }
+    // }TIME_DRIFT_CORRECTION
     buttonState buttonPressedTmp = buttonPressed;
     buttonPressed = None;
 

--- a/src/hardware/input/buttons.cpp
+++ b/src/hardware/input/buttons.cpp
@@ -42,6 +42,31 @@ buttonState useButton()
 }
 
 // Should be used only in watchface
+buttonState peekButton()
+{
+    buttMut.lock();
+    buttonState btn = buttonPressed;
+    buttMut.unlock();
+    return btn;
+}
+
+// Like useButton() but leaves LongUp/LongDown unconsumed so the cycling
+// check in watchfaceManageAll can catch them on the next loop iteration.
+buttonState useButtonNoLong()
+{
+    buttMut.lock();
+    if (buttonPressed == LongDown || buttonPressed == LongUp ||
+        buttonPressed == Back     || buttonPressed == LongBack)
+    {
+        buttMut.unlock();
+        return None;
+    }
+    buttonState tmp = buttonPressed;
+    buttonPressed = None;
+    buttMut.unlock();
+    return tmp;
+}
+
 buttonState useAllButtons()
 {
     buttMut.lock();

--- a/src/hardware/input/buttons.h
+++ b/src/hardware/input/buttons.h
@@ -10,6 +10,8 @@ extern TaskHandle_t buttonTask;
 buttonState useButtonBack();
 buttonState useButton();
 buttonState useAllButtons();
+buttonState peekButton();
+buttonState useButtonNoLong();
 void useButtonBlank();
 void loopButtonsTask(void *parameter);
 void manageButtonWakeUp();

--- a/src/hardware/input/buttons.h
+++ b/src/hardware/input/buttons.h
@@ -10,8 +10,6 @@ extern TaskHandle_t buttonTask;
 buttonState useButtonBack();
 buttonState useButton();
 buttonState useAllButtons();
-buttonState peekButton();
-buttonState useButtonNoLong();
 void useButtonBlank();
 void loopButtonsTask(void *parameter);
 void manageButtonWakeUp();

--- a/src/hardware/input/combinations.cpp
+++ b/src/hardware/input/combinations.cpp
@@ -88,15 +88,18 @@ bool wasClicked(uint8_t pin)
 void executeCombination()
 {
     resetSleepDelay(); // Faster so it won't escape...
-    if (wasClicked(MENU_PIN) == true && wasClicked(DOWN_PIN) == true && wasClicked(BACK_PIN) == false && wasClicked(UP_PIN) == false)
+    if (rM.currentPlace == watchface)
     {
-        cycleWatchfaceCombination(true);
-        return;
-    }
-    if (wasClicked(MENU_PIN) == true && wasClicked(UP_PIN) == true && wasClicked(BACK_PIN) == false && wasClicked(DOWN_PIN) == false)
-    {
-        cycleWatchfaceCombination(false);
-        return;
+        if (wasClicked(MENU_PIN) == true && wasClicked(DOWN_PIN) == true && wasClicked(BACK_PIN) == false && wasClicked(UP_PIN) == false)
+        {
+            cycleWatchfaceCombination(true);
+            return;
+        }
+        if (wasClicked(MENU_PIN) == true && wasClicked(UP_PIN) == true && wasClicked(BACK_PIN) == false && wasClicked(DOWN_PIN) == false)
+        {
+            cycleWatchfaceCombination(false);
+            return;
+        }
     }
     if (wasClicked(BACK_PIN) == true && wasClicked(UP_PIN) == true && wasClicked(MENU_PIN) == false && wasClicked(DOWN_PIN) == false)
     {

--- a/src/hardware/input/combinations.cpp
+++ b/src/hardware/input/combinations.cpp
@@ -1,5 +1,6 @@
 #include "combinations.h"
 #include "rtcMem.h"
+#include "../../ui/watchface/watchfaceManagers/wManageAll.h"
 
 #define BACK_INDEX 0
 #define MENU_INDEX 1
@@ -87,6 +88,16 @@ bool wasClicked(uint8_t pin)
 void executeCombination()
 {
     resetSleepDelay(); // Faster so it won't escape...
+    if (wasClicked(MENU_PIN) == true && wasClicked(DOWN_PIN) == true && wasClicked(BACK_PIN) == false && wasClicked(UP_PIN) == false)
+    {
+        cycleWatchfaceCombination(true);
+        return;
+    }
+    if (wasClicked(MENU_PIN) == true && wasClicked(UP_PIN) == true && wasClicked(BACK_PIN) == false && wasClicked(DOWN_PIN) == false)
+    {
+        cycleWatchfaceCombination(false);
+        return;
+    }
     if (wasClicked(BACK_PIN) == true && wasClicked(UP_PIN) == true && wasClicked(MENU_PIN) == false && wasClicked(DOWN_PIN) == false)
     {
         if (rM.currentPlace != wifiDebug)

--- a/src/ui/places/clockDebug/clockDebug.cpp
+++ b/src/ui/places/clockDebug/clockDebug.cpp
@@ -48,8 +48,10 @@ void resetDrift() {
     fsRemoveFile("/conf/" + String(CONF_DRIFT));
     fsRemoveFile("/conf/" + String(CONF_DRIFT_FAST));
     rM.SRTC.setDrift(0, 0);
+#if TIME_DRIFT_CORRECTION
     rM.driftStartUnix = 0;
     rM.driftDone = false;
+#endif
     slintExit();
     initClockDebug();
 }

--- a/src/ui/watchface/watchfaceManagers/wManageAll.cpp
+++ b/src/ui/watchface/watchfaceManagers/wManageAll.cpp
@@ -1,6 +1,7 @@
 #include "wManageAll.h"
 #include "rtcMem.h"
 
+
 #if WATCHFACE_ORBITAL
 #include "../watchfaces/orbital_Defaltastra/orbital.h"
 #endif
@@ -207,8 +208,54 @@ const watchfaceDefOne *getwatchfaceDefOne()
     return NULL;
 }
 
-void watchfaceManageAll(bool init)
+static void cycleTopLevel(bool forward)
 {
+    uint8_t i = rM.watchfaceSelected;
+    for (uint8_t n = 0; n < WATCHFACE_COUNT; n++)
+    {
+        i = forward ? (i + 1) % WATCHFACE_COUNT : (i + WATCHFACE_COUNT - 1) % WATCHFACE_COUNT;
+        if (watchfacesList[i]->manager != wfmNone)
+        {
+            rM.watchfaceSelected = i;
+            return;
+        }
+    }
+}
+
+static void handleCycle(bool forward)
+{
+    const watchfaceDef *cur = getCurrentWatchface();
+#if GSR_WATCHFACES
+    if (cur->manager == wfmGSR)
+    {
+        WatchyGSR *gsr = reinterpret_cast<WatchyGSR *>(cur->data);
+        if (forward && !gsr->AtLastStyle())  { gsr->NextStyle(); return; }
+        if (!forward && !gsr->AtFirstStyle()) { gsr->PrevStyle(); return; }
+    }
+#endif
+    cycleTopLevel(forward);
+#if GSR_WATCHFACES
+    // After a top-level switch, position sub-styles at the correct entry point
+    const watchfaceDef *next = getCurrentWatchface();
+    if (next->manager == wfmGSR)
+    {
+        WatchyGSR *gsr = reinterpret_cast<WatchyGSR *>(next->data);
+        if (forward) gsr->JumpToFirstStyle();
+        else         gsr->JumpToLastStyle();
+    }
+#endif
+}
+
+void cycleWatchfaceCombination(bool forward)
+{
+    handleCycle(forward);
+    rM.currentPlace = NoPlace;  // force initWatchfaceManage on next loop iteration
+}
+
+void watchfaceManageAll(bool initParam)
+{
+    bool init = initParam;
+
     const watchfaceDef *watchfaceSel = getCurrentWatchface();
     switch (watchfaceSel->manager)
     {

--- a/src/ui/watchface/watchfaceManagers/wManageAll.h
+++ b/src/ui/watchface/watchfaceManagers/wManageAll.h
@@ -12,4 +12,5 @@ const watchfaceDef *getCurrentWatchface();
 const watchfaceDefOne *getwatchfaceDefOne();
 void initWatchfaceManage();
 void loopWatchfaceManage();
+void cycleWatchfaceCombination(bool forward);
 

--- a/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.cpp
+++ b/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.cpp
@@ -112,4 +112,10 @@ void WatchyGSR::InsertInitWatchStyle(uint8_t StyleID) {}
 
 void WatchyGSR::RegisterWatchFaces(){};
 
+uint8_t WatchyGSR::GetCurrentStyleID() { return 1; }
+
+void WatchyGSR::NextStyle() {}
+
+void WatchyGSR::PrevStyle() {}
+
 #endif

--- a/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.cpp
+++ b/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.cpp
@@ -118,4 +118,12 @@ void WatchyGSR::NextStyle() {}
 
 void WatchyGSR::PrevStyle() {}
 
+bool WatchyGSR::AtLastStyle() { return true; }
+
+bool WatchyGSR::AtFirstStyle() { return true; }
+
+void WatchyGSR::JumpToFirstStyle() {}
+
+void WatchyGSR::JumpToLastStyle() {}
+
 #endif

--- a/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.h
+++ b/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.h
@@ -37,6 +37,10 @@ public:
     virtual uint8_t GetCurrentStyleID();
     virtual void NextStyle();
     virtual void PrevStyle();
+    virtual bool AtLastStyle();
+    virtual bool AtFirstStyle();
+    virtual void JumpToFirstStyle();
+    virtual void JumpToLastStyle();
 };
 
 struct TimeData final {

--- a/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.h
+++ b/src/ui/watchface/watchfaceManagers/wManageGSR/Watchy_GSR.h
@@ -34,6 +34,9 @@ public:
     virtual int GetWeatherTemperatureFeelsLike() final;
     virtual void InsertInitWatchStyle(uint8_t StyleID);
     virtual void RegisterWatchFaces();
+    virtual uint8_t GetCurrentStyleID();
+    virtual void NextStyle();
+    virtual void PrevStyle();
 };
 
 struct TimeData final {

--- a/src/ui/watchface/watchfaceManagers/wManageGSR/wManageGSR.cpp
+++ b/src/ui/watchface/watchfaceManagers/wManageGSR/wManageGSR.cpp
@@ -16,7 +16,7 @@ void wManageGsrLaunch(WatchyGSR *gsr, bool init)
 
     if (init == true)
     {
-        gsr->InsertInitWatchStyle(1);
+        gsr->InsertInitWatchStyle(gsr->GetCurrentStyleID());
         gsr->RegisterWatchFaces();
     }
 
@@ -33,19 +33,30 @@ void wManageGsrLaunch(WatchyGSR *gsr, bool init)
     }
 #endif
 
-    if (useButton() == Menu)
+    buttonState btn = useButton();
+    if (btn == Menu)
     {
         resetSleepDelay();
         generalSwitch(mainMenu);
     }
     else
     {
+        if (btn == LongDown)
+        {
+            gsr->NextStyle();
+            draw = true;
+        }
+        else if (btn == LongUp)
+        {
+            gsr->PrevStyle();
+            draw = true;
+        }
         setSleepDelay(0);
         if(draw == true) {
             dis->fillScreen(SCWhite);
-            gsr->InsertDrawWeather(1, true);
-            gsr->InsertDrawWatchStyle(1);
-            dUChange = true;    
+            gsr->InsertDrawWeather(gsr->GetCurrentStyleID(), true);
+            gsr->InsertDrawWatchStyle(gsr->GetCurrentStyleID());
+            dUChange = true;
         }
     }
     disUp();

--- a/src/ui/watchface/watchfaceManagers/wManageGSR/wManageGSR.cpp
+++ b/src/ui/watchface/watchfaceManagers/wManageGSR/wManageGSR.cpp
@@ -33,24 +33,13 @@ void wManageGsrLaunch(WatchyGSR *gsr, bool init)
     }
 #endif
 
-    buttonState btn = useButton();
-    if (btn == Menu)
+    if (useButton() == Menu)
     {
         resetSleepDelay();
         generalSwitch(mainMenu);
     }
     else
     {
-        if (btn == LongDown)
-        {
-            gsr->NextStyle();
-            draw = true;
-        }
-        else if (btn == LongUp)
-        {
-            gsr->PrevStyle();
-            draw = true;
-        }
         setSleepDelay(0);
         if(draw == true) {
             dis->fillScreen(SCWhite);

--- a/src/ui/watchface/watchfaces/gsr/classics/WatchyClassicsAddOn.h
+++ b/src/ui/watchface/watchfaces/gsr/classics/WatchyClassicsAddOn.h
@@ -7624,6 +7624,20 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
         InsertInitWatchStyle(gsrClassicsCurrentStyle);
     }
 
+    bool AtLastStyle() override { return gsrClassicsCurrentStyle == GSR_CLASSICS_COUNT; }
+
+    bool AtFirstStyle() override { return gsrClassicsCurrentStyle == 1; }
+
+    void JumpToFirstStyle() override {
+        gsrClassicsCurrentStyle = 1;
+        InsertInitWatchStyle(gsrClassicsCurrentStyle);
+    }
+
+    void JumpToLastStyle() override {
+        gsrClassicsCurrentStyle = GSR_CLASSICS_COUNT;
+        InsertInitWatchStyle(gsrClassicsCurrentStyle);
+    }
+
     void RegisterWatchFaces(){};
 
 // This function sets up the WatchFace Styles, this is required for AddOns,

--- a/src/ui/watchface/watchfaces/gsr/classics/WatchyClassicsAddOn.h
+++ b/src/ui/watchface/watchfaces/gsr/classics/WatchyClassicsAddOn.h
@@ -7589,16 +7589,7 @@ const unsigned char *marionumbers [10] = {mario0, mario1, mario2, mario3, mario4
 #define Y_PADDING 2*COIN_SPACING+COIN_H
 
 // Place all your Variables here.
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnBasicStyle = GSR_CLASSICS_BASICS;  // Remember RTC_DATA_ATTR for your variables so they don't get wiped on deep sleep.
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnSSegStyle = GSR_CLASSICS_7SEG;   // 7_SEG
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnDOSStyle = GSR_CLASSICS_DOS;    // DOS
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnPokeStyle = GSR_CLASSICS_POKE;   // Pokemon
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnStarryStyle = GSR_CLASSICS_STARRY; // Starry Horizon
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnTetrisStyle = GSR_CLASSICS_TETRIS; // Tetris
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnMacStyle = GSR_CLASSICS_MAC;    // Mac Paint
-RTC_DATA_ATTR uint8_t WatchyClassicsAddOnMarioStyle = GSR_CLASSICS_MARIO;  // Mario
-
-// If you want more than one WatchFaceStyle, make more variables and be sure to register them below in RegisterWatchFaces().
+RTC_DATA_ATTR uint8_t gsrClassicsCurrentStyle = GSR_CLASSICS_BASICS; // tracks which classic style is active
 
 // This is used to keep track of times you're in various looping functions (like AskForWiFi calling InsertWiFi).
 // Use more of these type of variables with the looping functions for various WatchFace Styles in this file.
@@ -7619,19 +7610,27 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
     public:
     WatchyClassicsAddOnClass() : WatchyGSR() { initAddOn(this); } // *** DO NOT EDIT THE CONTENTS OF THIS FUNCTION ***
 
+    uint8_t GetCurrentStyleID() override { return gsrClassicsCurrentStyle; }
 
-// This function is required by AddOns and is used to register one or more WatchFace Styles at startup, you can add more here, but you need more variables above
-// to track all of the WatchFaces and determine which ones match the CurrentStyleID(), as WatchFace Styles are collected and assigned at boot.
+    void NextStyle() override {
+        gsrClassicsCurrentStyle++;
+        if (gsrClassicsCurrentStyle > GSR_CLASSICS_COUNT) gsrClassicsCurrentStyle = 1;
+        InsertInitWatchStyle(gsrClassicsCurrentStyle);
+    }
 
-    void RegisterWatchFaces(){
+    void PrevStyle() override {
+        gsrClassicsCurrentStyle--;
+        if (gsrClassicsCurrentStyle < 1) gsrClassicsCurrentStyle = GSR_CLASSICS_COUNT;
+        InsertInitWatchStyle(gsrClassicsCurrentStyle);
+    }
 
-    };
+    void RegisterWatchFaces(){};
 
 // This function sets up the WatchFace Styles, this is required for AddOns,
 // as it sets up the Style when it is called for the first time and each time the Watchy is switched to another Watchface.
 
     void InsertInitWatchStyle(uint8_t StyleID){
-      if (StyleID == WatchyClassicsAddOnBasicStyle){
+      if (StyleID == GSR_CLASSICS_BASICS){
           Design.Face.Gutter = 5;
           Design.Face.Time = 113;
           Design.Face.TimeHeight = 53;
@@ -7639,7 +7638,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
           Design.Face.TimeFont = &DSEG7_Classic_Bold_53;
           Design.Face.TimeLeft = 5;
           Design.Face.TimeStyle = WatchyGSR::dRIGHT;
-      } else if (StyleID == WatchyClassicsAddOnSSegStyle){
+      } else if (StyleID == GSR_CLASSICS_7SEG){
           WantWeather(true);
           Design.Face.Gutter = 5;
           Design.Face.Time = 58;
@@ -7671,7 +7670,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
           Design.Status.BatteryInverted = false;
           Design.Status.BATTx = 154;
           Design.Status.BATTy = 73;
-      } else if (StyleID == WatchyClassicsAddOnMarioStyle){
+      } else if (StyleID == GSR_CLASSICS_MARIO){
           Design.Status.WIFIy = 163;
           Design.Status.BATTy = 148;
       }
@@ -7689,9 +7688,9 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
       FC = (LM ? BackColor() : ForeColor());
       BC = (LM ? ForeColor() : BackColor());
 
-      if (StyleID == WatchyClassicsAddOnBasicStyle){
+      if (StyleID == GSR_CLASSICS_BASICS){
           if (SafeToDraw()) SSeg_drawTime();
-      } else if (StyleID == WatchyClassicsAddOnSSegStyle){
+      } else if (StyleID == GSR_CLASSICS_7SEG){
           if (SafeToDraw()) SSeg_drawTime();
           display.setFont(&Seven_Segment10pt7b);
           String dayOfWeek = dayStr(WatchTime.Local.Wday + 1);
@@ -7725,7 +7724,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
                   display.fillRect(Design.Status.BATTx + 5 + (batterySegments * 9), Design.Status.BATTy + 5, 7, 11, ForeColor());
               }
           }
-      } else if (StyleID == WatchyClassicsAddOnDOSStyle){
+      } else if (StyleID == GSR_CLASSICS_DOS){
           T = MakeMinutes(WatchTime.Local.Hour) + ":" + MakeMinutes(WatchTime.Local.Minute);
           display.setTextColor(ForeColor());
           display.setFont(&Px437_IBM_BIOS5pt7b);
@@ -7752,14 +7751,14 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
           display.println(T);
           display.println(" ");
           display.print("<C:\\>esptool");
-      } else if (StyleID == WatchyClassicsAddOnPokeStyle){
+      } else if (StyleID == GSR_CLASSICS_POKE){
           display.drawBitmap(0, 0, WatchyClassic_Pokemon, 200, 200, SCBlack, SCWhite);
           T = MakeMinutes(WatchTime.Local.Hour) + ":" + MakeMinutes(WatchTime.Local.Minute);
           display.setTextColor(SCBlack);
           display.setFont(&FreeMonoBold9pt7b);
           display.setCursor(16, 165);
           display.print(T);
-      } else if (StyleID == WatchyClassicsAddOnStarryStyle) {
+      } else if (StyleID == GSR_CLASSICS_STARRY) {
           display.fillScreen(SCBlack);
           if (SafeToDraw() && NoMenu()){
               display.fillCircle(100, horizonY + planetR, planetR, SCWhite);
@@ -7777,7 +7776,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
           asprintf(&dateStr, "%s %s %d", dayOfWeek.c_str(), monthStr.c_str(), WatchTime.Local.Day);
           Starry_drawCenteredString(dateStr, 100, 140, true);
           free(dateStr);
-      } else if (StyleID == WatchyClassicsAddOnTetrisStyle) {
+      } else if (StyleID == GSR_CLASSICS_TETRIS) {
           display.drawBitmap(0, 0, tetrisbg, 200, 200, SCBlack, SCWhite);
           //Hour
           display.drawBitmap(25, 20, tetris_nums[WatchTime.Local.Hour/10], 40, 60, SCBlack, SCWhite); //first digit
@@ -7785,7 +7784,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
           //Minute
           display.drawBitmap(25, 110, tetris_nums[WatchTime.Local.Minute/10], 40, 60, SCBlack, SCWhite); //first digit
           display.drawBitmap(75, 110, tetris_nums[WatchTime.Local.Minute%10], 40, 60, SCBlack, SCWhite); //second digit
-      } else if (StyleID == WatchyClassicsAddOnMacStyle) {
+      } else if (StyleID == GSR_CLASSICS_MAC) {
           display.drawBitmap(0, 0, Mac_window, 200, 200, ForeColor());
           //Hour
           display.drawBitmap(35, 70, Mac_numbers[WatchTime.Local.Hour/10], 38, 50, ForeColor()); //first digit
@@ -7795,7 +7794,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
           //Minute
           display.drawBitmap(115, 70, Mac_numbers[WatchTime.Local.Minute/10], 38, 50, ForeColor()); //first digit
           display.drawBitmap(153, 70, Mac_numbers[WatchTime.Local.Minute%10], 38, 50, ForeColor()); //second digit
-      } else if (StyleID == WatchyClassicsAddOnMarioStyle) {
+      } else if (StyleID == GSR_CLASSICS_MARIO) {
           display.drawBitmap(0, 0, mariobg, 200, 200, ForeColor());
           int hour10 = WatchTime.Local.Hour/10;
           int hour01 = WatchTime.Local.Hour%10;
@@ -7827,7 +7826,7 @@ class WatchyClassicsAddOnClass : public WatchyGSR {
     void InsertDrawWeather(uint8_t StyleID, bool Status){
         int16_t  x1, y1;
         uint16_t w, h;
-        if (StyleID == WatchyClassicsAddOnSSegStyle){
+        if (StyleID == GSR_CLASSICS_7SEG){
             if (IsWeatherAvailable()){
                 const unsigned char* weatherIcon = getWeatherIcon(GetWeatherID());
                 String T = String(GetWeatherTemperatureFeelsLike());


### PR DESCRIPTION
config.h needs to be updated to be like this, but I don't know how to update config.h here...
Pressing menu and up or down for a little bit and letting go will shift between watch faces, including all the GSR classic watch faces.

```
#define GSR_CLASSICS 1
// Only one of them needs to be enabled at the time.
#define GSR_CLASSICS_BASICS  1
#define GSR_CLASSICS_7SEG    2
#define GSR_CLASSICS_DOS     3
#define GSR_CLASSICS_POKE    4
#define GSR_CLASSICS_STARRY  5
#define GSR_CLASSICS_TETRIS  6
#define GSR_CLASSICS_MAC     7
#define GSR_CLASSICS_MARIO   8
#define GSR_CLASSICS_COUNT   8
```